### PR TITLE
chore:  Use latest version of 3rd party actions in flutter-install

### DIFF
--- a/.github/actions/flutter-install/action.yml
+++ b/.github/actions/flutter-install/action.yml
@@ -43,7 +43,7 @@ runs:
         distribution: 'zulu'
         java-version: ${{ inputs.java-version }}
     - name: Set-up ssh-agent
-      uses: webfactory/ssh-agent@fc49353b67b2b7c1e0e6a600572d01a69f2672dd
+      uses: webfactory/ssh-agent@fd34b8dee206fe74b288a5e61bc95fba2f1911eb
       if: ${{ inputs.git-ssh-key != '' }}
       with:
         ssh-private-key: ${{ inputs.git-ssh-key }}

--- a/.github/actions/flutter-install/action.yml
+++ b/.github/actions/flutter-install/action.yml
@@ -30,7 +30,7 @@ runs:
   using: composite
   steps:
     - name: Install flutter environment
-      uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d
+      uses: subosito/flutter-action@02b923c0e1a5868734f1d56fa4083c3be4f554f3
       with:
         flutter-version: ${{ inputs.flutter-version }}
         architecture: ${{ inputs.flutter-architecture }}


### PR DESCRIPTION
Update [subosito/flutter-action](https://github.com/subosito/flutter-action) to the newest version available.
Update [webfactory/ssh-action](https://github.com/webfactory/ssh-agent/tree/master) to the newest version available.

This alone probably won't solve all problems with caching in flutter-install but I think it won't hurt. Problem is I cannot reproduce the issue.

I used this here https://github.com/dronetag/app/pull/344/files where I also fixed flutter version.

DT-2856