### PR TITLE
feat: add option to pass SSH agent socket in build-push-acr action

### DIFF
--- a/.github/actions/build-push-acr/action.yml
+++ b/.github/actions/build-push-acr/action.yml
@@ -28,6 +28,9 @@ inputs:
   actor:
     type: string
     required: true
+  ssh_socket_forward:
+    required: false
+    default: 'false'
 outputs:
   tags:
     value: ${{ steps.list.outputs.tags }}
@@ -60,11 +63,30 @@ runs:
       run: |
         REPOSITORY_URI="$REGISTRY/$REPOSITORY"
         echo "::set-output name=tags::$(echo $TAGS | sed "s|[^ ]*|$REPOSITORY_URI\:&\n|g")"
-    - name: Build and push
-      id: docker_build
+    - id: collect-ssh-config
+      name: Collect Git and SSH config files in a directory that is part of the Docker build context
+      if: ${{ inputs.ssh_socket_forward == 'true'}}
+      shell: bash
+      run: |
+        mkdir root-config
+        cp -r ~/.gitconfig  ~/.ssh root-config/
+    - id: docker_build
+      name: Build and push without SSH agent socket
+      if: ${{ inputs.ssh_socket_forward == 'false'}}
       uses: docker/build-push-action@v2
       with:
         context: .
         push: true
         build-args: ${{ inputs.build-args }}
         tags: "${{ steps.list.outputs.tags }}"
+    - id: docker_build-with-ssh
+      name: Build and push with SSH agent socket
+      if: ${{ inputs.ssh_socket_forward == 'true'}}
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        build-args: ${{ inputs.build-args }}
+        tags: "${{ steps.list.outputs.tags }}"
+        ssh: |
+            default=${{ env.SSH_AUTH_SOCK }}


### PR DESCRIPTION
Add `ssh_socket_forward` input to build-push-acr action.

If this input is `true`, collect Git and SSH config files in a directory that is part of the Docker build context and pass `env.SSH_AUTH_SOCK` to `docker/build-push-action`. I did not find a way to conditionally pass socket so I duplicated the step with ssh input.

DT-3074