### PR TITLE
fix: add pypi secrets to build-push workflow and action

### DIFF
--- a/.github/actions/build-push-acr/action.yml
+++ b/.github/actions/build-push-acr/action.yml
@@ -31,6 +31,15 @@ inputs:
   ssh_socket_forward:
     required: false
     default: 'false'
+  private-pypi-host:
+    type: string
+    required: false
+  private-pypi-user:
+    type: string
+    required: false
+  private-pypi-pass:
+    type: string
+    required: false
 outputs:
   tags:
     value: ${{ steps.list.outputs.tags }}
@@ -79,6 +88,10 @@ runs:
         push: true
         build-args: ${{ inputs.build-args }}
         tags: "${{ steps.list.outputs.tags }}"
+        secrets: |
+          "private_pip_url=${{ inputs.private-pypi-host }}"
+          "private_pip_username=${{ inputs.private-pypi-user }}"
+          "private_pip_password=${{ inputs.private-pypi-pass }}"
     - id: docker_build-with-ssh
       name: Build and push with SSH agent socket
       if: ${{ inputs.ssh_socket_forward == 'true'}}
@@ -90,3 +103,7 @@ runs:
         tags: "${{ steps.list.outputs.tags }}"
         ssh: |
             default=${{ env.SSH_AUTH_SOCK }}
+        secrets: |
+          "private_pip_url=${{ inputs.private-pypi-host }}"
+          "private_pip_username=${{ inputs.private-pypi-user }}"
+          "private_pip_password=${{ inputs.private-pypi-pass }}"

--- a/.github/workflows/acr-build-push-image.yml
+++ b/.github/workflows/acr-build-push-image.yml
@@ -24,6 +24,12 @@ on:
         required: true
       build-args:
         required: false
+      private-pypi-host:
+        required: false
+      private-pypi-user:
+        required: false
+      private-pypi-pass:
+        required: false
 
 jobs:
   build:
@@ -42,6 +48,9 @@ jobs:
           acr-username: ${{ secrets.acr-username }}
           acr-password: ${{ secrets.acr-password }}
           build-args: ${{ secrets.build-args }}
+          private-pypi-host: ${{ secrets.private-pypi-host }}
+          private-pypi-user: ${{ secrets.private-pypi-user }}
+          private-pypi-pass: ${{ secrets.private-pypi-pass }}
         with: 
           tags: ${{ inputs.tags }}
           repository-name: ${{ inputs.repository-name }}
@@ -51,4 +60,7 @@ jobs:
           acr-password: ${{ secrets.acr-password }}
           build-args: ${{ secrets.build-args }}
           actor: github.actor
+          private-pypi-host: ${{ secrets.private-pypi-host }}
+          private-pypi-user: ${{ secrets.private-pypi-user }}
+          private-pypi-pass: ${{ secrets.private-pypi-pass }}
           


### PR DESCRIPTION
Added optional inputs for secrets to `build-push` workflow and action. This should be correct according to [Using secrets with GitHub Actions – Docker Docs](https://docs.docker.com/build/ci/github-actions/secrets/).

Again, I am out of my depth here, so I am unsure if this fixes it.