### PR TITLE
update deprecated workflow

### DIFF
--- a/.github/actions/poetry-install/action.yml
+++ b/.github/actions/poetry-install/action.yml
@@ -63,7 +63,7 @@ runs:
       shell: bash
     - name: Load dependency cache
       id: cached-poetry-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: .venv
         key: venv-${{ github.repository }}-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
Update of depricated `actions/cache@v2` in favor of `actions/cache@v4`.
As stated in readme of [V4](https://www.npmjs.com/package/@actions/cache), all changes between v2 and v4 should be backwards compatible.