### PR TITLE
feat: allow passing ref to checkout when building image (DT-4349)

### DIFF
--- a/.github/actions/build-push-acr/action.yml
+++ b/.github/actions/build-push-acr/action.yml
@@ -7,6 +7,10 @@ inputs:
     type: string
     required: false
     default: latest
+  ref:
+    type: string
+    required: false
+    default: ''  # falsy value = fallback to default
   repository-name:
     type: string
     required: true
@@ -48,6 +52,8 @@ runs:
   steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with:
+        ref: ${{ inputs.ref }}
     - id: auth-acr
       name: Authenticate with ACR
       uses: azure/docker-login@v1

--- a/.github/workflows/acr-build-push-image.yml
+++ b/.github/workflows/acr-build-push-image.yml
@@ -13,6 +13,10 @@ on:
       repository-name:
         type: string
         required: true
+      ref:
+        type: string
+        required: false
+        default: ''  # falsy value
     secrets:
       github-token:
         required: true
@@ -53,6 +57,7 @@ jobs:
           private-pypi-pass: ${{ secrets.private-pypi-pass }}
         with: 
           tags: ${{ inputs.tags }}
+          ref: ${{ inputs.ref }}
           repository-name: ${{ inputs.repository-name }}
           github-token: ${{ secrets.github-token }}
           acr-login-server: ${{ secrets.acr-login-server }}


### PR DESCRIPTION
💡 Required by https://github.com/dronetag/airspace/pull/242

Fixes a problem during the building of the image. Prior to building, an incorrect commit is checked out. Instead of the commit produced by the semantic version step, the one that triggered the workflow is used. For that purpose, the build workflow and action now accept an optional `ref` which is by default set to `''` (a falsy value). This is done in order to avoid breaking other repositories that do not yet pass the `ref`, allowing for a gradual adoption of this fix/feature.  If nothing is passed, it should behave as before.

_For example_, the `airspace` service newly uses the `ref` because otherwise the automatic migrations will break. It passes the `tag` output of the semantic release (e.g., `v0.42.0`).