### PR TITLE
feat: make removal of version suffix optional when creating release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,6 +30,10 @@ on:
       install-yq:
         type: boolean
         default: false
+      strip-version-suffix:
+        description: "If true, strip any suffix from the tag (v1.2.3-rc.1 -> 1.2.3). If false, keep suffix (v1.2.3-rc.1 -> 1.2.3-rc.1)."
+        type: boolean
+        default: true
     secrets:
       github-token:
         required: true
@@ -73,8 +77,12 @@ jobs:
         id: export
         run: |
           VERSION=$(git describe --tags)
-          VERSION=$(echo "$VERSION" | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          if [[ "${{ inputs.strip-version-suffix }}" == 'true' ]]; then
+            VERSION=$(echo "$VERSION" | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
+          else
+            VERSION="${VERSION#v}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
   create-release:
     name: Create GitHub release version
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### Summary

This PR introduces a new reusable-workflow input: `strip-version-suffix`.

By default, this input is set to `true`, preserving the current behavior where any suffix
(e.g., `-rc.1`, `-beta`, etc.) is stripped from the generated version.

Repositories that want to keep version suffixes can now override this by setting:

```yaml
with:
  strip-version-suffix: false